### PR TITLE
Fix persistent stutter

### DIFF
--- a/sadx-frame-limit/mod.cpp
+++ b/sadx-frame-limit/mod.cpp
@@ -1,5 +1,11 @@
 #include "stdafx.h"
 
+#define FRAME_SKIP_MODE_DISABLE 0
+#define FRAME_SKIP_MODE_ACCUMULATE_ERROR 1
+#define FRAME_SKIP_MODE_DROP_ERROR 2
+
+#define FRAME_SKIP_MODE FRAME_SKIP_MODE_ACCUMULATE_ERROR
+
 DataPointer(LARGE_INTEGER, PerformanceFrequency, 0x03D08538);
 DataPointer(LARGE_INTEGER, PerformanceCounter, 0x03D08550);
 DataPointer(int, FrameMultiplier, 0x0389D7DC);
@@ -8,27 +14,89 @@ static constexpr int native_frames_per_second = 60;
 
 static bool enable_frame_limit = true;
 
+#if FRAME_SKIP_MODE != FRAME_SKIP_MODE_DISABLE
+static LARGE_INTEGER tick_start {};
+#endif
+
+#if FRAME_SKIP_MODE == FRAME_SKIP_MODE_ACCUMULATE_ERROR
+static LONGLONG tick_remainder = 0;
+#endif
+
 static void __cdecl FrameLimit_r();
-
 static Trampoline FrameLimit_t(0x007899E0, 0x007899E8, FrameLimit_r);
-
 static void __cdecl FrameLimit_r()
 {
 	if (enable_frame_limit && QueryPerformanceFrequency(&PerformanceFrequency))
 	{
-		const auto frequency = FrameMultiplier * PerformanceFrequency.QuadPart / native_frames_per_second;
+		const LONGLONG frequency = FrameMultiplier * PerformanceFrequency.QuadPart / native_frames_per_second;
 		LARGE_INTEGER counter;
+		LONGLONG elapsed;
 
 		do
 		{
 			QueryPerformanceCounter(&counter);
-		} while (counter.QuadPart - PerformanceCounter.QuadPart < frequency);
+			elapsed = counter.QuadPart - PerformanceCounter.QuadPart;
+		} while (elapsed < frequency);
 
 		PerformanceCounter = counter;
 	}
 	else
 	{
 		QueryPerformanceCounter(&PerformanceCounter);
+	}
+}
+
+static int __cdecl lmao_c()
+{
+#if FRAME_SKIP_MODE == FRAME_SKIP_MODE_DISABLE
+	return std::max<int>(0, FrameMultiplier - 1);
+#else
+	constexpr int to_usec = 1'000'000;
+	const LONGLONG frame_time_usec = to_usec / native_frames_per_second;
+
+	LARGE_INTEGER counter {};
+	QueryPerformanceCounter(&counter);
+
+	auto delta = ((counter.QuadPart - tick_start.QuadPart) * to_usec) / PerformanceFrequency.QuadPart;
+	tick_start = counter;
+
+	// FRAME_SKIP_MODE != FRAME_SKIP_MODE_DROP_ERROR
+#if FRAME_SKIP_MODE == FRAME_SKIP_MODE_ACCUMULATE_ERROR
+	delta += tick_remainder;
+#endif
+
+	const auto frames_to_rerun = std::max<int>(static_cast<int>(delta / frame_time_usec), 0);
+	const auto result = std::max(frames_to_rerun - 1, 0);
+
+#if FRAME_SKIP_MODE == FRAME_SKIP_MODE_ACCUMULATE_ERROR
+	const auto remainder = delta - (frame_time_usec * frames_to_rerun);
+
+	tick_remainder = remainder;
+
+	if (result != FrameMultiplier - 1)
+	{
+		PrintDebug("FUCK!!! Remainder: %lld\n", tick_remainder);
+	}
+
+	auto pad = ControllerPointers[0];
+	if (pad && pad->PressedButtons & Buttons_D)
+	{
+		// 0.25ms
+		tick_remainder += 250;
+	}
+#endif
+
+	return result;
+#endif
+}
+
+static const void* lmao_ret = (void*)0x00411DA3;
+static void __declspec(naked) lmao_asm()
+{
+	__asm
+	{
+		call lmao_c
+		jmp lmao_ret
 	}
 }
 
@@ -39,12 +107,17 @@ extern "C"
 	__declspec(dllexport) void __cdecl Init(const char* path, const HelperFunctions& helperFunctions)
 	{
 		QueryPerformanceCounter(&PerformanceCounter);
+#if FRAME_SKIP_MODE != FRAME_SKIP_MODE_DISABLE
+		tick_start = PerformanceCounter;
+#endif
 
 		// This patch changes 60.5 to 60, ensuring that the frame skip count at 0x3B11180
 		// is updated properly.
-		// FIXME: Unlike the default behavior, this can accumulate error and cause the some
+		// FIXME: Unlike the default behavior, this can accumulate error and cause some
 		// straddling of the target-frame time which can in the end induce a constant stutter.
 		WriteData<float>(reinterpret_cast<float*>(0x007DCE58), static_cast<float>(native_frames_per_second));
+
+		WriteJump((void*)0x00411D1C, lmao_asm);
 	}
 
 #ifdef _DEBUG

--- a/sadx-frame-limit/mod.ini
+++ b/sadx-frame-limit/mod.ini
@@ -1,6 +1,6 @@
 Name=Frame Limit
 Author=SonicFreak94
-Version=1.1
+Version=2.0
 Description=More precise framerate limiter.
 DLLFile=sadx-frame-limit.dll
 GitHubRepo=sonicfreak94/sadx-frame-Limit

--- a/sadx-frame-limit/sadx-frame-limit.vcxproj
+++ b/sadx-frame-limit/sadx-frame-limit.vcxproj
@@ -58,7 +58,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;DRAWDIST_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_WINDOWS;_USRDLL;DRAWDIST_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\sadx-mod-loader\SADXModLoader\include</AdditionalIncludeDirectories>
     </ClCompile>
@@ -77,7 +77,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;DRAWDIST_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;NDEBUG;_WINDOWS;_USRDLL;DRAWDIST_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\sadx-mod-loader\SADXModLoader\include</AdditionalIncludeDirectories>
     </ClCompile>

--- a/sadx-frame-limit/stdafx.h
+++ b/sadx-frame-limit/stdafx.h
@@ -2,6 +2,8 @@
 
 #define WIN32_LEAN_AND_MEAN
 
+#include <algorithm>
+
 #include <SADXModLoader.h>
 #include "../sadx-mod-loader/libmodutils/Trampoline.h"
 

--- a/sadx-frame-limit/stdafx.h
+++ b/sadx-frame-limit/stdafx.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#define WIN32_LEAN_AND_MEAN
+
 #include <SADXModLoader.h>
-#include <chrono>
 #include "../sadx-mod-loader/libmodutils/Trampoline.h"
+
+#include <Windows.h>


### PR DESCRIPTION
A long-standing issue caused by limiting the framerate to 60 FPS from the game's vanilla 61-62.5 FPS (or whatever) has been fixed. While frame delivery (present to display) was fine, every second or so, an extra game logic tick would execute to compensate for the "lag" induced by the limiter (again, going from >60 FPS to exactly 60 FPS), manifesting in a visible stutter. This means in-game time ran slightly fast as well.

This PR fixes this issue by disabling frame skip as a lag compensation mechanism. This is one of 3 modes currently configurable at compile time. There is also a mode which more closely resembles the original game's implementation, as well as a mode which uses a hybrid approach. Neither of these modes are recommended, and details are provided in the code comments.

One item that will need to be restored in the near future is the lenient wait loop. The last major version uses a CPU sleep for the majority of the frame wait time, then spins on the remainder. This implementation spins for the entire duration of the wait time. This may cause problems for some uses on low-end systems.